### PR TITLE
Craft double furnace from two normal ones

### DIFF
--- a/prototypes/recipe.lua
+++ b/prototypes/recipe.lua
@@ -6,8 +6,7 @@ data:extend({
     type = "recipe",
     name = "double-steel-furnace",
     ingredients = {
-      {type = "item", name = "steel-plate", amount = 12},
-      {type = "item", name = "stone-brick", amount = 10},
+      {type = "item", name = "steel-furnace", amount = 2},
     },
     results = {{type="item", name="double-steel-furnace", amount=1}},
     energy_required = 6,
@@ -20,9 +19,7 @@ data:extend({
     type = "recipe",
     name = "double-electric-furnace",
     ingredients = {
-      {type = "item", name = "steel-plate", amount = 20},
-      {type = "item", name = "advanced-circuit", amount = 10},
-      {type = "item", name = "stone-brick", amount = 20},
+      {type = "item", name = "electric-furnace", amount = 2},
     },
     results = {{type="item", name="double-electric-furnace", amount=1}},
     energy_required = 10,


### PR DESCRIPTION
Change Recipe to use Base Furnaces instead of Raw materials.

This makes it more player friendly once automated assembly of furnaces is set up.