### PR TITLE
Update to support 2.0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ GNU GPLv3
 
 # Changelog
 
+## 0.6.1
+- Updated to Factorio 2.0.16
+- Fix item sounds due to changes
+
 ## 0.6.0
 - Update to Factorio 2.0
 - Redo some (well, most...) of the graphics

--- a/info.json
+++ b/info.json
@@ -1,12 +1,12 @@
 {
   "name": "DoubleFurnace",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "title": "Double Furnace",
   "author": "raid",
   "contact": "mod@hackmate.de",
   "homepage": "https://mods.factorio.com/mods/raid/DoubleFurnace",
   "factorio_version": "2.0",
-  "dependencies": ["base >= 2.0"],
+  "dependencies": ["base >= 2.0.16"],
   "description": "Add a Double Furnace, which smelts iron ore directly to steel."
 }
 

--- a/prototypes/item.lua
+++ b/prototypes/item.lua
@@ -1,3 +1,5 @@
+local item_sounds = require("__base__.prototypes.item_sounds")
+
 data:extend({
 
   -- template was steel-furnace from data/base/prototypes/item.lua

--- a/prototypes/recipe.lua
+++ b/prototypes/recipe.lua
@@ -6,8 +6,7 @@ data:extend({
     type = "recipe",
     name = "double-steel-furnace",
     ingredients = {
-      {type = "item", name = "steel-plate", amount = 12},
-      {type = "item", name = "stone-brick", amount = 10},
+      {type = "item", name = "steel-furnace", amount = 2},
     },
     results = {{type="item", name="double-steel-furnace", amount=1}},
     energy_required = 6,
@@ -20,9 +19,7 @@ data:extend({
     type = "recipe",
     name = "double-electric-furnace",
     ingredients = {
-      {type = "item", name = "steel-plate", amount = 20},
-      {type = "item", name = "advanced-circuit", amount = 10},
-      {type = "item", name = "stone-brick", amount = 20},
+      {type = "item", name = "electric-furnace", amount = 2},
     },
     results = {{type="item", name="double-electric-furnace", amount=1}},
     energy_required = 10,


### PR DESCRIPTION
Increased version to 0.6.1
Updated dependencies to base >2.0.16 as fix won't work with 2.0.15

Updated item.lua to require the base item_sounds file. As item_sounds is no longer a global variable.